### PR TITLE
changed gid to serial instead of integer

### DIFF
--- a/jupyter/postgis_schemas/eccc_err_schema.sql
+++ b/jupyter/postgis_schemas/eccc_err_schema.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS public.eccc_storm_error_cones
 (
-    gid integer NOT NULL DEFAULT nextval('eccc_storm_error_cones_gid_seq'::regclass),
+    gid serial,
     "STORMNAME" character varying(80) COLLATE pg_catalog."default" NOT NULL,
     "TIMESTAMP" timestamp without time zone NOT NULL,
     geom geometry(MultiPolygon,4326),

--- a/jupyter/postgis_schemas/eccc_lin_schema.sql
+++ b/jupyter/postgis_schemas/eccc_lin_schema.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS public.eccc_storm_lines
 (
-    gid integer NOT NULL DEFAULT nextval('eccc_storm_lines_gid_seq'::regclass),
+    gid serial,
     "TIMESTAMP" timestamp without time zone NOT NULL,
     "STORMNAME" character varying(80) COLLATE pg_catalog."default" NOT NULL,
     "STORMTYPE" integer NOT NULL,

--- a/jupyter/postgis_schemas/eccc_pts_schema.sql
+++ b/jupyter/postgis_schemas/eccc_pts_schema.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS public.eccc_storm_points
 (
-    gid integer NOT NULL DEFAULT nextval('eccc_storm_points_gid_seq'::regclass),
+    gid serial,
     "STORMNAME" character varying(80) COLLATE pg_catalog."default" NOT NULL,
     "STORMTYPE" integer NOT NULL,
     "BASIN" character varying(80) COLLATE pg_catalog."default" NOT NULL,

--- a/jupyter/postgis_schemas/eccc_rad_schema.sql
+++ b/jupyter/postgis_schemas/eccc_rad_schema.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS public.eccc_storm_wind_radii
 (
-    gid integer NOT NULL DEFAULT nextval('eccc_storm_wind_radii_gid_seq'::regclass),
+    gid serial,
     "STORMNAME" character varying(80) COLLATE pg_catalog."default" NOT NULL,
     "WINDFORCE" numeric NOT NULL,
     "TIMESTAMP" timestamp without time zone NOT NULL,


### PR DESCRIPTION
Fixes issues with the create script dump from pgadmin that substituted the serial data type for an integer with a matching sequence.  Since PostgreSQL will create the appropriate sequence and remove it when the table is dropped we can simply the table schema to simply use serial instead.