### PR TITLE
Station data improvements

### DIFF
--- a/ERDDAP/cache_ERDDAP.py
+++ b/ERDDAP/cache_ERDDAP.py
@@ -333,6 +333,8 @@ def main():
     parser_historical.add_argument("--storm", help="The storm identifier, in the format of YYYY_stormname (lowercase). Example: 2022_fiona", nargs='?', type=storm_format)
     parser_historical.add_argument("--min", help="The start time of data in the storm interval. Format: YYYY", nargs='?', type=int)
     parser_historical.add_argument("--max", help="The end time of data in the storm interval. Format: YYYY", nargs='?', type=int)
+    parser_historical.add_argument("--dry", help="Dry run. Will grab from ERDDAP but not commit the data to the database", action="store_true")
+
     """
     parser_historical.add_argument("storm", help="The storm identifier, in the format of YYYY_stormname (lowercase). Example: 2022_fiona", type=storm_format)
     parser_historical.add_argument("min_time", help="The start time of data in the storm interval. Format: YYYY-mm-ddTHH:MM:SSZ", type=datetime_format)
@@ -346,6 +348,8 @@ def main():
         arg_storm = args.storm
         arg_year_min = args.min
         arg_year_max = args.max
+        arg_dry = args.dry
+        print(arg_dry)
         #min_time = datetime.strptime(args.min_time, '%Y-%m-%dT%H:%M:%SZ')
         #max_time = datetime.strptime(args.max_time, '%Y-%m-%dT%H:%M:%SZ')
 
@@ -374,10 +378,12 @@ def main():
                     cached_data.extend(cache_station_data(dataset, dataset_id, storm_id, 
                                                         min_time=datetime.strftime(min_time,'%Y-%m-%dT%H:%M:%SZ'), 
                                                         max_time=datetime.strftime(max_time,'%Y-%m-%dT%H:%M:%SZ')))
-            if(cached_data):
+            if(cached_data and not arg_dry):
                     print('Caching historical storm...')
                     cache_erddap_data(storm_id = storm_id, df=pd.DataFrame(cached_data),destination_table=pg_erddap_cache_historical_table,
                                         pg_engine=engine,table_schema=erddap_cache_historical_schema)
+            elif(arg_dry):
+                print("Dry run")
     # ACTIVE
     else:
         storm_id = "ACTIVE"

--- a/ERDDAP/cache_ERDDAP.py
+++ b/ERDDAP/cache_ERDDAP.py
@@ -236,7 +236,11 @@ def cache_station_data(dataset, dataset_id, storm_id, min_time, max_time):
                 # Might be able to only do the conversion during the 
                 # df_interval = df_interval[time_col].dt.strftime('%Y-%m-%dT%H:%M:%SZ')
                 # Change the dataframe to JSON, can change the format or orientation 
-                station_data = df_interval.to_json(orient="records")
+
+                # Experimental average binning per hour
+                #times = pd.to_datetime(df_interval[time_col])
+                df_interval = df_interval.groupby(pd.Grouper(key=time_col, axis=0, freq="h")).mean(numeric_only=True)
+                station_data = df_interval.reset_index().to_json(orient="records")
 
                 entry = {
                     "storm":storm_id,
@@ -349,7 +353,6 @@ def main():
         arg_year_min = args.min
         arg_year_max = args.max
         arg_dry = args.dry
-        print(arg_dry)
         #min_time = datetime.strptime(args.min_time, '%Y-%m-%dT%H:%M:%SZ')
         #max_time = datetime.strptime(args.max_time, '%Y-%m-%dT%H:%M:%SZ')
 

--- a/ERDDAP/config/config.ini
+++ b/ERDDAP/config/config.ini
@@ -28,4 +28,6 @@ max_lat = float
 
 [erddap_cache]
 active_data_period = 14
+post_storm_period = 2
 # Active storm monitoring period in days
+# Number of days post storm to still collect data from (historical)

--- a/react/components/active_storm_list.js
+++ b/react/components/active_storm_list.js
@@ -65,7 +65,7 @@ export default function ActiveStormList({ active_storm_data, setStormPoints, map
               <a onClick={(e) => { populateAllStormDetails(e, storm_details, setSelectedStorm, setStormPoints) }}>Show All</a>
             </li>
           ):(
-            <></>
+            <p>No data exists for active storms right now</p>
           )}
         </ul>
         

--- a/react/components/map.js
+++ b/react/components/map.js
@@ -97,7 +97,7 @@ export default function Map({ children, storm_points, storm_data, station_data, 
                 {
                   Object.entries(station_data).map((station) => {
                     const storm_timestamp = new Date(hover_marker.properties["TIMESTAMP"])
-                    return StationMarker(station, allDatasetDescriptions, storm_timestamp, setSelectedStation, setSelectedTab)
+                    return StationMarker(station, allDatasetDescriptions, storm_timestamp, selected_station, setSelectedStation, setSelectedTab)
                   })
                 }
               </LayerGroup>

--- a/react/components/station_dashboard/station_dashboard.js
+++ b/react/components/station_dashboard/station_dashboard.js
@@ -2,7 +2,7 @@ import { FaWindowClose } from "react-icons/fa";
 import { empty_station_obj } from "../layout"
 import { RenderWindRose } from "./wind_rose";
 import BasicTabs from "./tabs";
-import { RecentStationData, getDisplayName } from "../utils/station_data_format_util";
+import { RecentStationData, getDisplayName, getMatchedStation } from "../utils/station_data_format_util";
 import styles from '../station_marker.module.css'
 import RenderChart from '../station_graph.js'
 import { BlockquoteLeft } from "react-bootstrap-icons";
@@ -23,7 +23,13 @@ export default function StationDashboard({children, selected_station, setSelecte
         return null
   
       // Change to call from ERDDAP
-      const display_name = getDisplayName(station_descriptions, stationName);
+      //const display_name = getDisplayName(station_descriptions, stationName);
+      const station_description = getMatchedStation(station_descriptions, stationName)
+      const display_name = station_description.title
+      const institution = station_description.institution
+      const institution_link = station_description.institution_link
+      console.log(station_description)
+      console.log(institution_link)
   
       const exclude_var = ['time', 'latitude', 'longitude','relative_humidity',
         'sea_surface_wave_from_direction', 'sea_surface_wave_maximum_period'
@@ -61,6 +67,7 @@ export default function StationDashboard({children, selected_station, setSelecte
                     }}
                 ><FaWindowClose/></button>
                 <h3>{display_name}</h3>
+                <h3><a href={institution_link} target="_blank" rel="noopener noreferrer">{institution}</a></h3>
             </div>
             <div className="dash-body">
                 <p>

--- a/react/components/station_dashboard/station_graph/graph_config.js
+++ b/react/components/station_dashboard/station_graph/graph_config.js
@@ -1,0 +1,11 @@
+
+//Add alternate colours if first one is taken
+export var graph_colour = {
+    air_pressure: ['#d60019'],
+    sea_surface_wave_maximum_height:['#1f2b61'],
+    sea_surface_wave_significant_height:['#72768c'],
+    sea_surface_temperature:['#77bec9'],
+    air_temperature:['#cfe319'],
+    wind_speed_of_gust:['#636317'],
+    wind_speed:['#c4c41a']
+}

--- a/react/components/station_dashboard/tabs.js
+++ b/react/components/station_dashboard/tabs.js
@@ -46,6 +46,7 @@ export default function BasicTabs({stationName, stationData, stationSummaryText,
      height: 'auto',
      width: 'auto', // Adjust width based on content (chart)
      padding: '0px', // Optional padding around chart
+     display:'flex',
      }}>
      <RenderChart  
          sourceData={stationData}

--- a/react/components/station_graph.js
+++ b/react/components/station_graph.js
@@ -8,6 +8,8 @@ Chart.register(LineController, LineElement, LinearScale, PointElement, CategoryS
 
 
 function RenderChart({ sourceData, position, stationName, varCategory }) {
+
+
   const chartRef = useRef(null); // Reference to the canvas element
 
   const startAtZero = varCategory === 'air_pressure' ? false : true
@@ -47,10 +49,11 @@ function RenderChart({ sourceData, position, stationName, varCategory }) {
             },
           },
           responsive: true,
+          spanGaps:true,
           //maintainAspectRatio: false,
           plugins: {
             legend: {
-              position: 'right',
+              position: 'right'
             },
             title: {
               display: false,
@@ -105,6 +108,14 @@ const getRandomColor = () => {
   return color;
 };
 
+/*
+const getColour = (var) => {
+
+  let colour = '#'
+  colour = getRandomColor()
+  return colour
+}
+*/
 
 
 export default React.memo(RenderChart);
@@ -141,16 +152,16 @@ function parseChartData(sourceData, varCategory){
       const unit = get_station_field_units(sourceData, col_name)
       
       const data_obj = get_station_field_data(sourceData, col_name);
-      console.log(data_obj)
       const values = data_obj?.data
-
-      datasets.push({
-      label: `${data_obj.long_name} (${convert_unit_data(values[0], unit).unit})` || key, //  std_name if available
-      data: values.map((value)=>convert_unit_data(value,unit).value) || [], // Ensure that value exists
-      borderColor: getRandomColor(), // Generate random colors for each line
-      backgroundColor: 'rgba(0, 0, 0, 0)',
-      fill: false,
-      })
+      // If array of values is empty / all null skip it
+      if(!values.every(element => element === null)) {
+        datasets.push({
+        label: `${data_obj.long_name} (${convert_unit_data(values[0], unit).unit})` || key, //  std_name if available
+        data: values.map((value)=>convert_unit_data(value,unit).value) || [], // Ensure that value exists
+        borderColor: getRandomColor(), // Generate random colors for each line
+        backgroundColor: 'rgba(0, 0, 0, 0)',
+        fill: false,
+      })}
       
     });
     

--- a/react/components/station_graph.js
+++ b/react/components/station_graph.js
@@ -119,7 +119,7 @@ function parseChartData(sourceData, varCategory){
 
   const station_timeData = get_station_field_data(sourceData,"time", "column_std_names")?.data
   const timeData = station_timeData.map((timestamp) => new Date(timestamp).toLocaleString('en-US', {
-                            //hour: '2-digit',
+                            hour: '2-digit',
                             //minute: '2-digit',
                             day: '2-digit',
                             month: '2-digit',

--- a/react/components/station_graph.js
+++ b/react/components/station_graph.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { Chart, LineElement, LinearScale, PointElement, CategoryScale, Tooltip, Legend, LineController} from 'chart.js';
 import { get_station_field_data, get_station_field_units, get_station_field_position, getColumnNameList, getUniqueStdNamesList } from './utils/station_data_format_util';
 import { convert_unit_data, windSpeedToKmh, windSpeedToKnots } from './utils/unit_conversion';
+import { graph_colour } from './station_dashboard/station_graph/graph_config.js'
 
 // Register necessary components, including the Line controller
 Chart.register(LineController, LineElement, LinearScale, PointElement, CategoryScale, Tooltip, Legend);
@@ -108,14 +109,13 @@ const getRandomColor = () => {
   return color;
 };
 
-/*
-const getColour = (var) => {
-
-  let colour = '#'
-  colour = getRandomColor()
-  return colour
+function getColour(graph_colour_list, var_name){
+  let colour = '';
+  console.log(var_name)
+  console.log(graph_colour_list)
+  colour = var_name in graph_colour_list ? graph_colour[var_name] : getRandomColor()
+  return colour;
 }
-*/
 
 
 export default React.memo(RenderChart);
@@ -147,7 +147,10 @@ function parseChartData(sourceData, varCategory){
     console.log(variable)
 
     const column_names_list = getColumnNameList(column_std_names, column_names, variable)
-
+    
+    var graph_colour_list = {}
+    Object.assign(graph_colour_list, graph_colour);
+    console.log(graph_colour_list)
     column_names_list.forEach(col_name => {
       const unit = get_station_field_units(sourceData, col_name)
       
@@ -158,7 +161,7 @@ function parseChartData(sourceData, varCategory){
         datasets.push({
         label: `${data_obj.long_name} (${convert_unit_data(values[0], unit).unit})` || key, //  std_name if available
         data: values.map((value)=>convert_unit_data(value,unit).value) || [], // Ensure that value exists
-        borderColor: getRandomColor(), // Generate random colors for each line
+        borderColor: getColour(graph_colour_list, variable), // Generate random colors for each line
         backgroundColor: 'rgba(0, 0, 0, 0)',
         fill: false,
       })}

--- a/react/components/station_marker.js
+++ b/react/components/station_marker.js
@@ -5,7 +5,7 @@ import RenderChart from './station_graph.js'
 import { flip_coords } from "@/lib/storm_utils";
 import { empty_station_obj } from "./layout"
 
-import { Marker, Popup } from "react-leaflet";
+import { Marker, Tooltip, Popup, Icon } from "react-leaflet";
 
 import { getDisplayName } from "./utils/station_data_format_util";
 import styles from './station_marker.module.css'
@@ -19,7 +19,15 @@ import styles from './station_marker.module.css'
  * @param {Date} time Time of the station data to retrieve. Defaults to most recent data if not provided
  * @returns StationMarker JavaScript snippet
  */
-export default function StationMarker(station_data, station_descriptions, time = new Date(), setSelectedStation, setSelectedTab) {
+export default function StationMarker(station_data, station_descriptions, time = new Date(), selected_station, setSelectedStation, setSelectedTab) {
+    // Turns selected marker red, others return as blue
+    function getMarkerIcon(){
+      if (station_name === selected_station[0]){
+        return redIcon
+      }
+      else return blueIcon
+    }
+
     if(isNaN(time))
       time= new Date()
 
@@ -40,23 +48,32 @@ export default function StationMarker(station_data, station_descriptions, time =
     //const display_name = (station_name in station_names) ? station_names[station_name]['display']:station_name
 
     // Data for station doesn't exist at the provided time
+    const redIcon = new L.Icon.Default({
+      iconUrl:'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/refs/heads/master/img/marker-icon-2x-red.png'
+    })
+
+    const blueIcon = new L.Icon.Default()
+    let selectedIcon = new L.Icon.Default()
+
     
+
 
     return (
       <Marker 
         key={station_name} 
         position={flip_coords(station_values?.geometry?.coordinates)}
+        icon={getMarkerIcon(station_name)}
         eventHandlers={{
           click: (e) => {
             console.log(e, "SETTING SELECTED STATION", station_data);
             setSelectedStation(station_data);
             setSelectedTab(0);
-          },
+          }
         }}
       >
-          <Popup > 
+          <Tooltip> 
             <h4>{display_name}</h4>
-          </Popup>
+          </Tooltip>
         </Marker>
     )
 }

--- a/react/components/utils/station_data_format_util.js
+++ b/react/components/utils/station_data_format_util.js
@@ -8,8 +8,6 @@ export function get_station_field_data(station_data, field_name, name_type='colu
     const arrayColumn = (arr, n) => arr.map(x => x[n]);
     const field_position = get_station_field_position(station_data,field_name,name_type)
     const field_data = arrayColumn(station_data['rows'], field_position)
-    console.log(field_position)
-    console.log( station_data["column_long_names"][field_position])
     const field_obj = {    
     data: field_data || null,
     standard_name: station_data?.['column_std_names']?.[field_position] || null,
@@ -87,7 +85,6 @@ export function RecentStationData(data, time) {
 
 export function getDisplayName(station_descriptions, station_name){
     let display_name;
-
     const matchedDataset = station_descriptions?.find(station_description => station_description.id === station_name);
     
     if (matchedDataset) {
@@ -98,6 +95,15 @@ export function getDisplayName(station_descriptions, station_name){
       display_name = station_name
     }
     return display_name;
+}
+
+export function getMatchedStation(station_descriptions, station_name){
+  const matchedDataset = station_descriptions?.find(station_description => station_description.id === station_name);
+  
+  if (matchedDataset) {
+    return matchedDataset
+  }
+  return null
 }
 
 

--- a/react/components/utils/unit_conversion.js
+++ b/react/components/utils/unit_conversion.js
@@ -1,6 +1,7 @@
 export function convert_unit_data (value, unit_from, unit_to=null){
   // Checks for certain values to convert or just reformat  
-  return (unit_from == 'm/s' && unit_to == 'knots') ? windSpeedToKnots(value)
+  return (value == null) ? {'value':NaN, 'unit':unit_from}
+  : (unit_from == 'm/s' && unit_to == 'knots') ? windSpeedToKnots(value)
   : (unit_from == 'm/s') ? windSpeedToKmh(value) //km/h default instead of m/s
   : (unit_from == 'm s-1') ? windSpeedToKmh(value) //km/h default instead of m/s
   : (unit_from == 'km h-1') ? {'value':value, 'unit':'km/h'} //km/h default instead of m/s

--- a/react/pages/api/all_erddap_dataset.js
+++ b/react/pages/api/all_erddap_dataset.js
@@ -59,11 +59,13 @@ async function fetchDatasetMetadata(datasetID) {
     const attributes = metadata.table.rows;
     //console.log(attributes)
     const description = attributes.find(attr => attr[2] === "summary")?.[4] || "No description available.";
-    const institution = attributes.find(attr => attr[2] === "institution")?.[4] || "No institution available.";
+    const institution = attributes.find(attr => attr[2] === "creator_name")?.[4] || "No institution available.";
+    const institution_link = attributes.find(attr => attr[2] === "creator_url")?.[4] || "No URL available";
 
     const info = {
       description,
-      institution
+      institution,
+      institution_link
     }
 
     //console.log(`Dataset Description for ${datasetID}: ${description}`);
@@ -86,6 +88,7 @@ async function fetchAllDatasetDescriptions() {
         title: dataset.title,
         description: info.description,
         institution: info.institution,
+        institution_link: info.institution_link
       };
     })
   );

--- a/react/styles/globals.css
+++ b/react/styles/globals.css
@@ -167,24 +167,27 @@ footer {
 .station_dashboard {
   background: white;
   color: black;
-  border-top: 3px solid #e55162;
-  padding: 2rem;
+  /*border-top: 3px solid #e55162;*/
+  padding: 1rem;
   margin-left: 20%;
   position: absolute;
-  bottom: 50px;
+  bottom: 20px;
   z-index: 5000;
   width: 80%;
 }
 
-/* Styling for the dashboard header */
+/* Styling for the dashboard header 
+  */
 .station_dashboard .dash-header {
-  border: 1px solid darkgoldenrod;
+  /*border: 1px solid darkgoldenrod;*/
+  background-color: #eee;
+  padding:0.5rem;
 }
 
 /* Handles the styling of buttons in the header */
 .station_dashboard .dash-header button {
   float: right;
-  background-color: #fff;
+  background-color: #eee;
   border: 0;
   font-size: 1.5rem;
 }
@@ -194,12 +197,14 @@ footer {
   font-weight: bold;
 }
 
-/* Styling for the dashboard body */
+/* Styling for the dashboard body
 .station_dashboard .dash-body {
   border: 1px solid green;
 }
+  */
 
-/* Styling for the dashboard footer */
+/* Styling for the dashboard footer 
 .station_dashboard .dash-footer {
   border: 1px solid blue;
 }
+  */


### PR DESCRIPTION
Added some improvements to station drawer and data. Still some work to be done on the issue (#58) , but some of these (binning to one hour, null data fix) could be good to get in now.

**Station Data**
- Added an extra two day period after the storm end date to provide a clearer sense of the storm vs. post storm period. Time value can be changed in config file.
- Averages out incoming data into 1 hour intervals to cut down on some of the larger datasets
- Added option to dry-run caching script for testing purposes

**Station Graph**
- Chart will ignore null values (previously would default to 0)
- If all data for a variable is null for the time period, chart will no longer draw it

**Dashboard**
- Added institution information and link to their page
- Minor UI changes (removed borders, added background, changed padding)

**Other**
- Added message to storm list if no active storms are recorded at the moment